### PR TITLE
Build fix for the CPP example.

### DIFF
--- a/CPP/DesktopToastsSample.cpp
+++ b/CPP/DesktopToastsSample.cpp
@@ -12,7 +12,7 @@
 #include <wrl.h>
 #include <wrl\wrappers\corewrappers.h>
 #include <windows.ui.notifications.h>
-#include "notificationactivationcallback.h"
+#include "NotificationActivationCallback.h"
 
 //  Name:     System.AppUserModel.ToastActivatorCLSID -- PKEY_AppUserModel_ToastActivatorCLSID
 //  Type:     Guid -- VT_CLSID

--- a/CPP/DesktopToastsSample.vcxproj
+++ b/CPP/DesktopToastsSample.vcxproj
@@ -22,6 +22,7 @@
     <ProjectGuid>{77CC36BE-AD64-4AD3-95C6-0F352F6A3FE3}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>DesktopToastsSample</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
NotificationActivationCallback.h is not found because
the target platform is incorrectly put to 8.1 if you have
have the 8.1 SDK installed. It will not build as the header
is not included in that SDK. Enforcing to 10+ will make it compile.

Also renamed the include to follow
https://msdn.microsoft.com/en-us/library/windows/desktop/mt643711(v=vs.85).aspx
which uses a camelcase name : NotificationActivationCallback.h
