### PR TITLE
Update the C# sample to use the new Windows 10 toast API

### DIFF
--- a/CS/DesktopToastsSample.csproj
+++ b/CS/DesktopToastsSample.csproj
@@ -71,6 +71,7 @@
     </Reference>
     <Reference Include="Windows.Data" />
     <Reference Include="Windows.UI" />
+    <Reference Include="Windows.Foundation" />
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/CS/DesktopToastsSample.csproj
+++ b/CS/DesktopToastsSample.csproj
@@ -32,7 +32,7 @@
     <RootNamespace>DesktopToastsSample</RootNamespace>
     <AssemblyName>DesktopToastsSample</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetPlatformVersion>8.1</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.10240.0</TargetPlatformVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
@@ -69,7 +69,8 @@
     <Reference Include="System.Xaml">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>
-    <Reference Include="Windows" />
+    <Reference Include="Windows.Data" />
+    <Reference Include="Windows.UI" />
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/CS/MainWindow.xaml.cs
+++ b/CS/MainWindow.xaml.cs
@@ -120,10 +120,47 @@ namespace DesktopToastsSample
 
             // Create the toast and attach event listeners
             ToastNotification toast = new ToastNotification(toastXml);
+            toast.Activated += ToastActivated;
+            toast.Dismissed += ToastDismissed;
+            toast.Failed += ToastFailed;
 
             // Show the toast. Be sure to specify the AppUserModelId on your application's shortcut!
             ToastNotificationManager.CreateToastNotifier(APP_ID).Show(toast);
         }
 
+        private void ToastActivated(ToastNotification sender, object e)
+        {
+            ToastActivated();
+        }
+
+        private void ToastDismissed(ToastNotification sender, ToastDismissedEventArgs e)
+        {
+            String outputText = "";
+            switch (e.Reason)
+            {
+                case ToastDismissalReason.ApplicationHidden:
+                    outputText = "The app hid the toast using ToastNotifier.Hide";
+                    break;
+                case ToastDismissalReason.UserCanceled:
+                    outputText = "The user dismissed the toast";
+                    break;
+                case ToastDismissalReason.TimedOut:
+                    outputText = "The toast has timed out";
+                    break;
+            }
+
+            Dispatcher.Invoke(() =>
+            {
+                Output.Text = outputText;
+            });
+        }
+
+        private void ToastFailed(ToastNotification sender, ToastFailedEventArgs e)
+        {
+            Dispatcher.Invoke(() =>
+            {
+                Output.Text = "The toast encountered an error.";
+            });
+        }
     }
 }

--- a/CS/MainWindow.xaml.cs
+++ b/CS/MainWindow.xaml.cs
@@ -120,9 +120,9 @@ namespace DesktopToastsSample
 
             // Create the toast and attach event listeners
             ToastNotification toast = new ToastNotification(toastXml);
-            toast.Activated += ToastActivated;
-            toast.Dismissed += ToastDismissed;
-            toast.Failed += ToastFailed;
+            //toast.Activated += ToastActivated;
+            //toast.Dismissed += ToastDismissed;
+            //toast.Failed += ToastFailed;
 
             // Show the toast. Be sure to specify the AppUserModelId on your application's shortcut!
             ToastNotificationManager.CreateToastNotifier(APP_ID).Show(toast);

--- a/CS/MainWindow.xaml.cs
+++ b/CS/MainWindow.xaml.cs
@@ -120,47 +120,10 @@ namespace DesktopToastsSample
 
             // Create the toast and attach event listeners
             ToastNotification toast = new ToastNotification(toastXml);
-            //toast.Activated += ToastActivated;
-            //toast.Dismissed += ToastDismissed;
-            //toast.Failed += ToastFailed;
 
             // Show the toast. Be sure to specify the AppUserModelId on your application's shortcut!
             ToastNotificationManager.CreateToastNotifier(APP_ID).Show(toast);
         }
 
-        private void ToastActivated(ToastNotification sender, object e)
-        {
-            ToastActivated();
-        }
-
-        private void ToastDismissed(ToastNotification sender, ToastDismissedEventArgs e)
-        {
-            String outputText = "";
-            switch (e.Reason)
-            {
-                case ToastDismissalReason.ApplicationHidden:
-                    outputText = "The app hid the toast using ToastNotifier.Hide";
-                    break;
-                case ToastDismissalReason.UserCanceled:
-                    outputText = "The user dismissed the toast";
-                    break;
-                case ToastDismissalReason.TimedOut:
-                    outputText = "The toast has timed out";
-                    break;
-            }
-
-            Dispatcher.Invoke(() =>
-            {
-                Output.Text = outputText;
-            });
-        }
-
-        private void ToastFailed(ToastNotification sender, ToastFailedEventArgs e)
-        {
-            Dispatcher.Invoke(() =>
-            {
-                Output.Text = "The toast encountered an error.";
-            });
-        }
     }
 }

--- a/CS/NotificationActivator.cs
+++ b/CS/NotificationActivator.cs
@@ -20,9 +20,9 @@ namespace DesktopToastsSample
 
         public static void Initialize()
         {
-            var regService = new RegistrationServices();
+            regService = new RegistrationServices();
 
-            int cookie = regService.RegisterTypeForComClients(
+            cookie = regService.RegisterTypeForComClients(
                 typeof(NotificationActivator),
                 RegistrationClassContext.LocalServer,
                 RegistrationConnectionType.MultipleUse);


### PR DESCRIPTION
Since the C# sample seems to be Windows 10 only, I think that it can be useful to update it to be able to use the new adaptive and interactive toast notifications for Windows 10. I used version `10.0.10240.0`, don't know if I should use a more recent one.

Got a little confused in the commits, i can reopen a new PR with one commit if you want.
